### PR TITLE
fix: add missing player functions

### DIFF
--- a/types/qbx_core/server_functions.lua
+++ b/types/qbx_core/server_functions.lua
@@ -176,6 +176,16 @@ function exports.qbx_core:GetGroups(source) end
 function exports.qbx_core:GetPlayersData() end
 
 ---**`server`**
+---@param identifier Source | CitizenId
+---@param key string
+---@param value any
+function exports.qbx_core:SetPlayerData(identifier, key, value) end
+
+---**`server`**
+---@param identifier Source | CitizenId
+function exports.qbx_core:UpdatePlayerData(identifier) end
+
+---**`server`**
 ---@param filters table <string, any>
 ---@return Player[]
 function exports.qbx_core:SearchPlayers(filters) end

--- a/types/qbx_core/server_functions.lua
+++ b/types/qbx_core/server_functions.lua
@@ -142,8 +142,7 @@ function exports.qbx_core:IsPlayerBanned(source) end
 
 ---**`server`**
 ---@see client/lua:Notify
-function exports.qbx_core:Notify(source, text, notifyType, duration, subTitle, notifyPosition, notifyStyle, notifyIcon,
-                                 notifyIconColor) end
+function exports.qbx_core:Notify(source, text, notifyType, duration, subTitle, notifyPosition, notifyStyle, notifyIcon, notifyIconColor) end
 
 ---**`server`**
 ---@param InvokingResource string

--- a/types/qbx_core/server_functions.lua
+++ b/types/qbx_core/server_functions.lua
@@ -142,7 +142,8 @@ function exports.qbx_core:IsPlayerBanned(source) end
 
 ---**`server`**
 ---@see client/lua:Notify
-function exports.qbx_core:Notify(source, text, notifyType, duration, subTitle, notifyPosition, notifyStyle, notifyIcon, notifyIconColor) end
+function exports.qbx_core:Notify(source, text, notifyType, duration, subTitle, notifyPosition, notifyStyle, notifyIcon,
+                                 notifyIconColor) end
 
 ---**`server`**
 ---@param InvokingResource string


### PR DESCRIPTION
this pr adds missing player functions for qbx_core
```lua
---@param identifier Source | CitizenId
---@param key string
---@param value any
exports.qbx_core:SetPlayerData(identifier, key, value)

---@param identifier Source | CitizenId
exports.qbx_core:UpdatePlayerData(identifier)
```

